### PR TITLE
Bugfixes 11-23

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -34,13 +34,3 @@ jobs:
         release_name: Automated Release ${{ github.run_number }}
         tag_name: release/${{ github.run_number }}
         asset_files: ${{env.mod_name}}.zip
-    - name: Create Workshop Release
-      if: env.workshop_id
-      uses: weilbyte/steam-workshop-upload@v1
-      with: 
-        appid: 294100 # Rimworld's Steam App ID
-        itemid: ${{env.workshop_id}} # Your mod's Steam Workshop ID
-        path: ${{env.mod_name}} # Path to your mod's folder from repository root
-      env:
-        STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }} # Your Steam username
-        STEAM_PASSWORD: ${{ secrets.STEAM_PASSWORD }} # Your Steam password

--- a/Source/Core.cs
+++ b/Source/Core.cs
@@ -36,7 +36,7 @@ namespace MusicExpanded
             List<ThemeDef> themes = DefDatabase<ThemeDef>.AllDefs.ToList();
 
             // The height of individual ThemeDef entries. 
-            float entryHeight = 140f;
+            float entryHeight = 180f;
             viewHeight = entryHeight * themes.Count() + 40f;
 
             Rect viewRect = new Rect(0f, 0f, inRect.width - 18f, viewHeight);


### PR DESCRIPTION
Fixes #34 
[What's That Mod](https://steamcommunity.com/sharedfiles/filedetails/?id=2258431182) adds to the description, which pushed the button below the visible area. A follow up should be made to make this flex so that descriptions of any length are supported.

Fixes #30 
Removes automated steam releases. They aren't going to work with how steam is set up right now.