### PR TITLE
Misc Work 12-3

### DIFF
--- a/Source/Def/TrackDef.cs
+++ b/Source/Def/TrackDef.cs
@@ -15,12 +15,14 @@ namespace MusicExpanded
         public static MethodInfo vanillaAppropriateNow = AccessTools.Method(typeof(RimWorld.MusicManagerPlay), "AppropriateNow");
         public bool IsBattleTrack => (cue <= Cue.BattleLegendary && cue >= Cue.BattleSmall);
         public List<BiomeDef> allowedBiomes;
+        public List<TechLevel> allowedTechLevels;
         public bool AppropriateNow(SongDef lastPlayed = null, Cue cueMatch = Cue.None)
         {
             if (
                 (cue == Cue.HasColonistNamed && Find.CurrentMap != null && !Find.CurrentMap.PlayerPawnsForStoryteller.Where((pawn) => Utilities.NameMatches(pawn, cueData)).Any())
                 || (cue != cueMatch || (lastPlayed != null && lastPlayed == this))
                 || (allowedBiomes != null && Find.CurrentMap != null && !allowedBiomes.Contains(Find.CurrentMap.Biome))
+                || (allowedTechLevels != null && !allowedTechLevels.Contains(Find.FactionManager.OfPlayer.def.techLevel))
             )
                 return false;
 

--- a/Source/Patches/MusicManagerPlay.cs
+++ b/Source/Patches/MusicManagerPlay.cs
@@ -18,6 +18,7 @@ namespace MusicExpanded.Patches
         {
             static bool Prefix(RimWorld.MusicManagerPlay __instance, ref SongDef __result)
             {
+                Log.Message("choosing next song");
                 if (!Verse.Prefs.RunInBackground && !Core.settings.vanillaMusicUpdate)
                 {
                     Log.Error("Using Music Expanded Framework while RimWorld's setting \"RunInBackground\" is disabled is known to cause issues! Enabling \"vanillaMusicUpdate\" setting in Music Expanded Framework settings to ensure proper compatibility. If you'd like to use our custom update, enable RimWorld's \"Run In Background\" setting, and disable Music Expanded Frameworks's \"Vanilla Music Update\"");
@@ -35,9 +36,11 @@ namespace MusicExpanded.Patches
                 // Battle track decay
                 if (lastTrack != null)
                 {
+                    Log.Message("Battle track?");
                     TrackDef lastTrackAsTrackDef = ThemeDef.TrackByDefName(lastTrack.defName);
                     if (lastTrackAsTrackDef != null && lastTrackAsTrackDef.IsBattleTrack)
                     {
+                        Log.Message("it's a battle track, decay it");
 
                         Map map = Find.AnyPlayerHomeMap ?? Find.CurrentMap;
                         if (map.dangerWatcher.DangerRating == StoryDanger.High)
@@ -51,6 +54,7 @@ namespace MusicExpanded.Patches
 
                 if (tracks == null || !tracks.Any())
                 {
+                    Log.Message("Narrowing down tracks to appropriate");
                     tracks = ThemeDef.ActiveTheme.tracks.Where(track => track.AppropriateNow(lastTrack));
                 }
                 if (!tracks.Any())
@@ -58,6 +62,7 @@ namespace MusicExpanded.Patches
                     Log.Warning("Tried to play a track from the theme, but none were appropriate right now. This theme requires more tracks.");
                     return false;
                 }
+                Log.Message("Actually returning chosen track.");
                 SongDef chosenTrack = tracks.RandomElementByWeight((TrackDef s) => s.commonality) as SongDef;
                 Utilities.ShowNowPlaying(chosenTrack);
                 __result = chosenTrack;
@@ -84,11 +89,14 @@ namespace MusicExpanded.Patches
             static bool Prefix(RimWorld.MusicManagerPlay __instance)
             {
                 bool gameObjectCreated = (bool)MusicManagerPlay.gameObjectCreated.GetValue(__instance);
-                if (Core.settings.vanillaMusicUpdate || !gameObjectCreated || __instance.IsPlaying || __instance.disabled)
+                if (Core.settings.vanillaMusicUpdate || !gameObjectCreated || __instance.disabled)
                     return true;
                 try
                 {
-                    startNewSong.Invoke(__instance, null);
+                    Log.Message("Starting new song");
+                    Log.Message(__instance.DebugString());
+                    if (!__instance.IsPlaying)
+                        startNewSong.Invoke(__instance, null);
                 }
                 catch
                 {

--- a/Source/Patches/MusicManagerPlay.cs
+++ b/Source/Patches/MusicManagerPlay.cs
@@ -18,6 +18,11 @@ namespace MusicExpanded.Patches
         {
             static bool Prefix(RimWorld.MusicManagerPlay __instance, ref SongDef __result)
             {
+                if (!Verse.Prefs.RunInBackground && !Core.settings.vanillaMusicUpdate)
+                {
+                    Log.Error("Using Music Expanded Framework while RimWorld's setting \"RunInBackground\" is disabled is known to cause issues! Enabling \"vanillaMusicUpdate\" setting in Music Expanded Framework settings to ensure proper compatibility. If you'd like to use our custom update, enable RimWorld's \"Run In Background\" setting, and disable Music Expanded Frameworks's \"Vanilla Music Update\"");
+                    Core.settings.vanillaMusicUpdate = true;
+                }
                 System.Object forcedSong = MusicManagerPlay.forcedSong.GetValue(__instance);
                 if (forcedSong != null)
                 {

--- a/Source/Utilities.cs
+++ b/Source/Utilities.cs
@@ -26,7 +26,7 @@ namespace MusicExpanded
         public static void ShowNowPlaying(SongDef song)
         {
             if (Core.settings.showNowPlaying)
-                Messages.Message("ME_NowPlaying".Translate(song.label).ToString(), null, MessageTypeDefOf.NeutralEvent, null, false);
+                Messages.Message("ME_NowPlaying".Translate(song.label).ToString(), null, MessageTypeDefOf.SilentInput, null, false);
         }
         public static Cue BattleCue(float points)
         {


### PR DESCRIPTION
Silent Now Playing notification
Closes #33
Adds allowedTechLevels to TrackDefs, to allow tracks to only play for specific tech levels.
Closes #43 
Adds an error message, and resolves setting incompatibility when RimWorld is configured in a way to interfere with Music Expanded's update method.
Closes #46 

Fixed bug where tense moments in gameplay cause music tracks to keep switching.
Closes #40 